### PR TITLE
Sidebar improvements

### DIFF
--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -14,10 +14,10 @@ export default function Layout() {
       <TopBar />
       <Content>
         <Grid container spacing={2}>
-          <Grid item xs={isSidebarOpened ? 3 : 1}>
+          <Grid item xs={isSidebarOpened ? 3 : 2}>
             <SideBar />
           </Grid>
-          <Grid item xs={isSidebarOpened ? 9 : 11}>
+          <Grid item xs={isSidebarOpened ? 9 : 10}>
             <Outlet />
           </Grid>
         </Grid>

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { InteractiveComponentsContext } from 'contexts/interactiveComponentsContext';
-import { styled } from '@mui/material/styles';
+import { styled, useTheme } from '@mui/material/styles';
 import {
   Box,
   Drawer,
@@ -13,10 +13,11 @@ import {
   ListItemIcon,
   ListItemText,
 } from '@mui/material';
-import { Menu as MenuIcon, ChevronLeft as ChevronLeftIcon } from '@mui/icons-material';
+import {
+  ChevronLeft as ChevronLeftIcon,
+  ChevronRight as ChevronRightIcon,
+} from '@mui/icons-material';
 import { SIDEBAR_BUTTONS_LIST } from 'constants/icons';
-
-const DRAWER_WIDTH = 240;
 
 const DrawerHeader = styled('div')(({ theme }) => ({
   display: 'flex',
@@ -27,50 +28,70 @@ const DrawerHeader = styled('div')(({ theme }) => ({
 }));
 
 export default function Sidebar() {
-  const { isSidebarOpened, toggleSidebar } = useContext(InteractiveComponentsContext);
+  const { isSidebarOpened, toggleSidebar, selectedIndex, selectIndex } = useContext(
+    InteractiveComponentsContext,
+  );
+  const theme = useTheme();
+  const DRAWER_WIDTH = isSidebarOpened ? 210 : 100;
 
   return (
     <Box sx={{ display: 'flex' }}>
       <CssBaseline />
-      <IconButton
-        color='secondary'
-        aria-label='open drawer'
-        onClick={toggleSidebar}
-        edge='start'
-        sx={{ mr: 2, ...(isSidebarOpened && { display: 'none' }) }}
-      >
-        <MenuIcon sx={{ position: 'fixed', left: '5px' }} />
-      </IconButton>
       <Drawer
         sx={{
           width: DRAWER_WIDTH,
+          transition: 'width 0.2s',
           flexShrink: 0,
           '& .MuiDrawer-paper': {
             width: DRAWER_WIDTH,
+            transition: 'width 0.2s',
             boxSizing: 'border-box',
             top: 65,
-            backgroundColor: '#111827',
-            color: '#A0AEC0',
+            backgroundColor: theme.palette.primary.dark,
+            color: theme.palette.text.secondary,
           },
         }}
         variant='persistent'
         anchor='left'
-        open={isSidebarOpened}
+        open={true}
       >
         <DrawerHeader>
-          <IconButton onClick={toggleSidebar}>
-            <ChevronLeftIcon color='secondary' />
+          <IconButton
+            onClick={toggleSidebar}
+            sx={[{ '&:hover': { backgroundColor: theme.palette.common.white } }]}
+          >
+            {isSidebarOpened ? (
+              <ChevronLeftIcon color='secondary' />
+            ) : (
+              <ChevronRightIcon color='secondary' />
+            )}
           </IconButton>
         </DrawerHeader>
         <Divider />
-        <List>
+        <List
+          sx={{
+            '&& .Mui-selected': {
+              backgroundColor: '#303b54',
+            },
+          }}
+        >
           {SIDEBAR_BUTTONS_LIST.map(({ key, Icon }) => (
-            <ListItemButton key={key} divider={true}>
-              <ListItem key={key}>
+            <ListItemButton
+              key={key}
+              divider={true}
+              selected={selectedIndex === key}
+              onClick={() => selectIndex(key)}
+            >
+              <ListItem
+                key={key}
+                sx={{
+                  height: 89,
+                }}
+              >
                 <ListItemIcon>
                   <Icon fontSize='large' color='secondary' />
                 </ListItemIcon>
-                <ListItemText primary={key} />
+                {isSidebarOpened && <ListItemText primary={key} />}
               </ListItem>
             </ListItemButton>
           ))}

--- a/src/constants/icons.ts
+++ b/src/constants/icons.ts
@@ -1,8 +1,6 @@
 import {
   GridOnOutlined as GridOnOutlinedIcon,
-  DescriptionOutlined as DescriptionOutlinedIcon,
   PlagiarismOutlined as PlagiarismOutlinedIcon,
-  LaptopWindowsOutlined as LaptopWindowsOutlinedIcon,
   ScreenSearchDesktopOutlined as ScreenSearchDesktopOutlinedIcon,
   SettingsOutlined as SettingsOutlinedIcon,
   PersonOutlineOutlined as PersonOutlineOutlinedIcon,
@@ -14,16 +12,8 @@ export const SIDEBAR_BUTTONS_LIST = [
     Icon: GridOnOutlinedIcon,
   },
   {
-    key: 'Document',
-    Icon: DescriptionOutlinedIcon,
-  },
-  {
     key: 'Cautare Documente',
     Icon: PlagiarismOutlinedIcon,
-  },
-  {
-    key: 'Proiect',
-    Icon: LaptopWindowsOutlinedIcon,
   },
   {
     key: 'Cautare Proiecte',

--- a/src/contexts/interactiveComponentsContext.tsx
+++ b/src/contexts/interactiveComponentsContext.tsx
@@ -1,26 +1,38 @@
 import React, { createContext, useState } from 'react';
+import { SIDEBAR_BUTTONS_LIST } from 'constants/icons';
 
 export interface InteractiveComponentsState {
   isSidebarOpened: boolean;
   toggleSidebar: () => void;
+  selectedIndex: string;
+  selectIndex: (index: string) => void;
 }
 
 const InteractiveComponentsDefaultState: InteractiveComponentsState = {
   isSidebarOpened: true,
   toggleSidebar: () => null,
+  selectedIndex: '',
+  selectIndex: () => null,
 };
 
 export const InteractiveComponentsContext = createContext(InteractiveComponentsDefaultState);
 
 export const InteractiveComponentsProvider = ({ children }: any) => {
   const [isSidebarOpened, setIsSidebarOpened] = useState(true);
+  const [selectedIndex, setSelectedIndex] = useState(SIDEBAR_BUTTONS_LIST[0].key);
+
+  function selectIndex(index: string) {
+    setSelectedIndex(index);
+  }
 
   function toggleSidebar() {
     setIsSidebarOpened(!isSidebarOpened);
   }
 
   return (
-    <InteractiveComponentsContext.Provider value={{ isSidebarOpened, toggleSidebar }}>
+    <InteractiveComponentsContext.Provider
+      value={{ isSidebarOpened, toggleSidebar, selectedIndex, selectIndex }}
+    >
       {children}
     </InteractiveComponentsContext.Provider>
   );


### PR DESCRIPTION
Following the demo session feedback, the following changed:

- Removed 'Proiect' and 'Document' buttons
- Changed from a state of closed to minimised, in which now only the icons are visible
- Added a 'selected' functionality to the buttons
- Open/close button is now better highlighted
___
![Screenshot 2022-11-17 at 10 44 23](https://user-images.githubusercontent.com/36814085/202398995-b2fff320-d8f3-4e3a-a26e-3a749cd08724.png)
___
![Screenshot 2022-11-17 at 10 45 03](https://user-images.githubusercontent.com/36814085/202399030-2d1ee160-080a-40e6-a05c-88456ff8d558.png)
